### PR TITLE
Fix setting maxSize on initial ASG creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stack",
-  "version": "0.0.73",
+  "version": "0.0.74",
   "license": "None",
   "private": true,
   "type": "module",

--- a/src/stacks/PodStack.ts
+++ b/src/stacks/PodStack.ts
@@ -643,11 +643,17 @@ su ${podOptions.sshUser} /home/${podOptions.sshUser}/init.sh
 
       if (!replaceAsgEachDeploy || podOptions.deploy._preserveAsg) {
         let minSize = Math.max(1, podOptions.autoscaling.minHealthyInstances);
-        let maxSize = 2;
+        let maxSize = Math.max(
+          2,
+          minSize,
+          Math.ceil(
+            minSize * (podOptions.autoscaling.minHealthyPercentage / 100)
+          )
+        );
         let desiredCapacity = Math.max(1, minSize);
         if (options.currentAsg) {
           minSize = options.currentAsg.minSize ?? 1;
-          maxSize = options.currentAsg.maxSize ?? 2;
+          maxSize = options.currentAsg.maxSize ?? maxSize;
           desiredCapacity = options.currentAsg.desiredCapacity ?? 1;
         }
 


### PR DESCRIPTION
This avoids an error where we were setting the default maxSize to 2, causing:

    ValidationError: Max bound, 2, must be greater than or equal to min bound, 4

This happens if the minSize in the `.stack/deploy.yaml` file is set to a
value larger than `2`.
