### PR TITLE
Switch Docker Hub image namespace to `farcasterxyz`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker/login-action@v3
         with:
-          username: ${{ vars.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_WRITE_PASSWORD }}
+          username: ${{ vars.FARCASTERXYZ_DOCKERHUB_USER }}
+          password: ${{ secrets.FARCASTERXYZ_DOCKERHUB_WRITE_PASSWORD }}
       - uses: depot/setup-action@v1
       - run: env STACK_VERSION=${{ github.sha }} ./bin/publish-image.sh
         shell: bash
@@ -35,8 +35,8 @@ jobs:
       # Should already be built, we just want to publish the specific version tag
       - uses: docker/login-action@v3
         with:
-          username: ${{ vars.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_WRITE_PASSWORD }}
+          username: ${{ vars.FARCASTERXYZ_DOCKERHUB_USER }}
+          password: ${{ secrets.FARCASTERXYZ_DOCKERHUB_WRITE_PASSWORD }}
       - uses: depot/setup-action@v1
       - run: env STACK_VERSION=${{ github.ref_name }} ./bin/publish-image.sh
         shell: bash

--- a/bin/exec-stack-via-docker.sh
+++ b/bin/exec-stack-via-docker.sh
@@ -53,7 +53,7 @@ if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
     -e "CI=$CI" \
     -v "${SSH_AUTH_SOCK:-/ssh-agent}:/ssh-agent" \
     -e SSH_AUTH_SOCK=/ssh-agent \
-    merklemanufactory/stack:$STACK_VERSION "$@"
+    farcasterxyz/stack:$STACK_VERSION "$@"
 else
   # Otherwise explicitly forward AWS auth envars
   exec docker run --rm $interactive_flags \
@@ -63,7 +63,7 @@ else
     -e "CI=$CI" \
     -v "${SSH_AUTH_SOCK:-/ssh-agent}:/ssh-agent" \
     -e SSH_AUTH_SOCK=/ssh-agent \
-    merklemanufactory/stack:$STACK_VERSION "$@"
+    farcasterxyz/stack:$STACK_VERSION "$@"
 fi
 
 # Build process will append the version tag to this file so it can be used

--- a/bin/publish-image.sh
+++ b/bin/publish-image.sh
@@ -15,6 +15,6 @@ echo "Publishing Stack $STACK_VERSION"
 depot build -f Dockerfile \
   --platform "linux/amd64,linux/arm64" \
   --push \
-  -t merklemanufactory/stack:${STACK_VERSION} \
-  -t merklemanufactory/stack:latest \
+  -t farcasterxyz/stack:${STACK_VERSION} \
+  -t farcasterxyz/stack:latest \
   .


### PR DESCRIPTION
Since we switched from `warpcast` to `merkle-team`, the name needs to be updated. However, `merkle-team` isn't available as a name.

Just use `farcasterxyz` for now.
